### PR TITLE
feat: lsp mode for prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ P.S. I have quite limited time for this, so I'd be happy for good pull requests 
 
 - Syntax hilighting
 - Autoindent
-
-## No :(
-
 - LSP
 
 ## Installation
@@ -18,13 +15,13 @@ P.S. I have quite limited time for this, so I'd be happy for good pull requests 
 I'm using [doom-emacs](https://github.com/hlissner/doom-emacs), so to have the mode available I clone the repo to `~/.doom.d/emacs-prisma-mode`, then in `~/.doom.d/config.el` I can set:
 
 ```elisp
-(load "~/.doom.d/emacs-prisma-mode/prisma-mode.el")
+(load! "emacs-prisma-mode/prisma-mode")
 ```
 
 Or, you can also install as package at `~/.doom.d/packages.el`
 
 ```elisp
-(package! another-package :recipe (:host github :repo "pimeys/emacs-prisma-mode" :branch "main"))
+(package! prisma-mode :recipe (:host github :repo "pimeys/emacs-prisma-mode" :branch "main"))
 ```
 
 ## Screenshot

--- a/lsp-prisma.el
+++ b/lsp-prisma.el
@@ -1,0 +1,53 @@
+;;; lsp-prisma.el --- Description -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Harshit Pant
+;;
+;; Author: Harshit Pant <https://github.com/pantharshit00>
+;; Maintainer: Harshit Pant <pantharshit00@gmail.com>
+;; Created: February 18, 2021
+;; Modified: February 18, 2021
+;; Version: 0.0.1
+;; Keywords: Symbol’s value as variable is void: finder-known-keywords
+;; Homepage: https://github.com/pimeys/emacs-prisma-mode/
+;; Package-Requires: ((emacs "24.3"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  Description
+;;
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-prisma nil
+  "LSP support for Prisma using official lsp"
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/pimeys/emacs-prisma-mode"))
+
+(lsp-dependency 'prisma-language-server
+                '(:system "prisma-language-server")
+                '(:npm :package "@prisma/language-server"
+                  :path "prisma-language-server"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection  (lambda ()
+                     `(,(lsp-package-path 'prisma-language-server)
+                       "--stdio"))) 
+                  :major-modes '(prisma-mode)
+                  :server-id 'prismals
+                  :activation-fn (lambda (file-name _mode)
+                   (string= (f-ext file-name)
+                            "prisma"))
+                  :download-server-fn (lambda (_client callback error-callback _update?)
+                                        (lsp-package-ensure
+                                         'prisma-language-server
+                                         callback
+                                         error-callback))
+                                         ))
+(add-to-list 'lsp-language-id-configuration '(prisma-mode . "prisma"))
+
+(provide 'lsp-prisma)
+;;; lsp-prisma.el ends here
+

--- a/prisma-mode.el
+++ b/prisma-mode.el
@@ -17,6 +17,7 @@
 ;;; Commentary:
 ;;; Code:
 
+(require 'lsp-prisma)
 (setq prisma-font-lock-keywords
       (let* (
              ;; We match `model Album {', and highlight `model' as keyword and `Album' as type.


### PR DESCRIPTION
I saw this in my random todo list and decided to give it a shot. It works!

Screenshot:
![image](https://user-images.githubusercontent.com/22195362/112804938-9d15ab00-9092-11eb-8e73-33057cb4d024.png)


You need node and npm installed then you can install the lsp without much trouble via `lsp-install-server` command. 

I also updated the install instructions. `doom/upgrade` will be required after merge.