### PR TITLE
hack to fix indent after op

### DIFF
--- a/prisma-mode.el
+++ b/prisma-mode.el
@@ -76,6 +76,8 @@
   (setq c-basic-offset 2)
   (setq c-syntactic-indentation nil)
   (setq js-indent-level 2)
+  ;; HACK: dont indent after <type>[?!]
+  (setq-local js--indent-operator-re "")
   (setq font-lock-defaults '((prisma-font-lock-keywords))))
 
 ;;;###autoload


### PR DESCRIPTION
This is a hack to fix indentation after statements ending in `[?!]`.
An advice like `(advice-add 'js--looking-at-operator-p :override #'ignore)`
would probably be better, but I don't think it is currently possibly to advise
functions locally.