### PR TITLE
Fix header syntax for quelpa installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Or, you can also install as package at `~/.doom.d/packages.el`
 ```elisp
 (package! prisma-mode :recipe (:host github :repo "pimeys/emacs-prisma-mode" :branch "main"))
 ```
+
+Or, you can [use-package](https://github.com/jwiegley/use-package) and [quelpa-use-package](https://github.com/quelpa/quelpa-use-package)
+
+```elisp
+(use-package prisma-mode
+  :quelpa (prisma-mode :fetcher github :repo "pimeys/emacs-prisma-mode" :branch "main"))
+```
+
+
 Note: This package requires [lsp-mode](https://github.com/emacs-lsp/lsp-mode)
 
 ```elisp

--- a/lsp-prisma.el
+++ b/lsp-prisma.el
@@ -15,7 +15,7 @@
 ;;
 ;;; Commentary:
 ;;
-;;  Description
+;;; Description:
 ;;
 ;;; Code:
 

--- a/prisma-mode.el
+++ b/prisma-mode.el
@@ -18,6 +18,8 @@
 
 ;;; Commentary:
 
+;;; Description:
+
 ;;; Syntax highlight and LSP functionality for the Prisma Schema Language. Using
 ;;; the LSP functionality requires the npm package @prisma/language-server to
 ;;; be installed in the system, providing prisma-language-server somewhere in


### PR DESCRIPTION
This PR fixes the header description syntax which was causing installation to fail with errors like: https://github.com/quelpa/quelpa-use-package/issues/14

This PR also updates the README to have an example of `use-package` installation